### PR TITLE
Configuration File for SMTP Settings

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -18,5 +18,7 @@ mail_worker: 2
 smtp:
   host: '<provider_smtp_host>'
   port: '<provider_smtp_port>'
-  username: '<smtp_login>'
+  login: '<smtp_login>'
   password: '<smtp_password>'
+  full_name: '<receiver_name>'
+  email_address: '<receiver_email>'

--- a/.env_sample
+++ b/.env_sample
@@ -1,0 +1,22 @@
+---
+
+# @author Bodo (Hugo) Barwich
+# @version 2024-02-04
+# @package Grafana Alerting
+# @subpackage .env
+
+# This is the Default Service Configuration
+# This will be overwritten in different Deployment Environments
+#
+
+component: 'unknown'
+project: 'Actix Alerting Email'
+web_root: '/'
+main_directory: ''
+config_file: ''
+mail_worker: 2
+smtp:
+  host: '<provider_smtp_host>'
+  port: '<provider_smtp_port>'
+  username: '<smtp_login>'
+  password: '<smtp_password>'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,9 +15,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch Config
+      run: echo "${{ secrets.APP_CONFIG }}" > .env
+    - name: Node Mail Test
+      run: |
+        cd scripts/mailer
+        npm install --no-save
+        node index.js
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: |
-        echo "${{ secrets.APP_CONFIG }}" > .env
-        cargo test -- --show-output
+      run: cargo test -- --show-output

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,4 +18,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test -- --show-output
+      run: |
+        echo "${{ secrets.APP_CONFIG }}" > .env
+        cargo test -- --show-output

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ target
 target/**
 */target
 */target/**
+
+#Exclude Node Modules
+**/node_modules/**

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.adoc
 Cargo.lock
 
+#Exclude Local Configurations
+.env
+
 #Exclude Build Files
 target
 target/**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Bodo Hugo Barwich <b.barwich@hotmail.com>"]
 edition = "2018"
 
 [[bin]]
-name = "grafana-alerting-email"
+name = "actix-alerting-email"
 path = "src/main.rs"
 
 [lib]
@@ -20,13 +20,18 @@ tokio = "=0.1.14"
 futures = "=0.1.29"
 futures-core = "=0.3.11"
 futures-util = "*"
+lettre = "=0.9.6"
+lettre_email = "0.9"
+native-tls = "0"
 mime = "0.3.9"
 log = "0.4"
 env_logger = "0.7"
 anyhow = "1.0.31"
 failure = "=0.1.7"
-serde = { version = "1.0.41", features = ["derive"] }
+serde = { version = "1.0.106", features = ["derive"] }
+serde_derive = "1.0.106"
 serde_json = "1.0.41"
+serde_yaml = "=0.8.11"
 json = "0.12.0"
 
 [profile.release]

--- a/scripts/mailer/index.js
+++ b/scripts/mailer/index.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const yaml = require('js-yaml');
+const nodemailer = require('nodemailer');
+
+let config = undefined;
+
+try {
+    let configfile = fs.readFileSync('../../.env', 'utf8');
+
+    config = yaml.load(configfile);
+} catch (e) {
+    console.log("Config Load failed: " + e);
+}
+
+if(config) {
+  var transporter = nodemailer.createTransport({
+    name: config.component + '.local',
+    host: config.smtp.host,
+    port: config.smtp.port,
+    secure: false,
+    requireTLS: true,
+    auth: {
+      user: config.smtp.login,
+      pass: config.smtp.password
+    },
+    logger: true,
+    debug: true,
+  });
+
+  var mailOptions = {
+    from: config.smtp.email_address,
+    to: config.smtp.email_address,
+    subject: '[Mail Test - ' + config.component + '] Node Email Test ('
+      + process.env.GITHUB_RUN_ID + ')',
+    text: 'Mail Test (' + process.env.GITHUB_RUN_ID + ') - ' + config.component
+      + "\n=============================\n\nmy Node test email message"
+  };
+
+  transporter.sendMail(mailOptions, function(error, info){
+    if (error) {
+      console.log("Email failed: " + error);
+    } else {
+      console.log('Email sent: ' + info.response);
+    }
+  });
+}

--- a/scripts/mailer/package.json
+++ b/scripts/mailer/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mailer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "nodemailer": "^6.9.8"
+  }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,303 @@
+/*
+* @author Bodo (Hugo) Barwich
+* @version 2024-01-31
+* @package Grafana Alerting
+* @subpackage Configuration Loader
+
+* This Module defines functions to load the application configuration
+*
+*---------------------------------
+* Requirements:
+*/
+
+extern crate serde;
+extern crate serde_yaml;
+
+use serde_derive::{Deserialize, Serialize};
+use std::ffi::OsStr;
+use std::fs;
+use std::io::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+const CONFIG_FILE: &'static str = ".env";
+
+//==============================================================================
+// Structure SMTPConfig Declaration
+
+/// Structure for the SMTP Configuration
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SMTPConfig {
+    pub host: String,
+    pub port: String,
+    pub login: String,
+    pub password: String,
+    pub full_name: String,
+    pub email_address: String
+}
+
+//==============================================================================
+// Structure AppConfig Declaration
+
+/// Structure for the Application Configuration
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppConfig {
+    pub component: String,
+    pub project: String,
+    pub web_root: String,
+    pub main_directory: String,
+    pub config_file: String,
+    pub mail_worker: u16,
+    pub smtp: SMTPConfig,
+}
+
+//==============================================================================
+// Structure AppConfig Implementation
+
+impl Default for SMTPConfig {
+    /*----------------------------------------------------------------------------
+     * Default Constructor
+     */
+
+    fn default() -> Self {
+        SMTPConfig::new()
+    }
+}
+
+impl SMTPConfig {
+    /*----------------------------------------------------------------------------
+     * Constructors
+     */
+
+    pub fn new() -> SMTPConfig {
+        SMTPConfig {
+            host: String::new(),
+            port: String::new(),
+            login: String::new(),
+            password: String::new(),
+            full_name: String::new(),
+            email_address: String::new()
+        }
+    }
+}
+
+impl Clone for SMTPConfig {
+    /*----------------------------------------------------------------------------
+     * Administrative Methods
+     */
+
+    fn clone(&self) -> SMTPConfig {
+        SMTPConfig {
+            host: self.host.clone(),
+            port: self.port.clone(),
+            login: self.login.clone(),
+            password: self.password.clone(),
+            full_name: self.full_name.clone(),
+            email_address: self.email_address.clone()
+        }
+    }
+}
+
+//==============================================================================
+// Structure AppConfig Implementation
+
+impl Default for AppConfig {
+    /*----------------------------------------------------------------------------
+     * Default Constructor
+     */
+
+    fn default() -> Self {
+        AppConfig::new()
+    }
+}
+
+impl AppConfig {
+    /*----------------------------------------------------------------------------
+     * Constructors
+     */
+
+    pub fn new() -> AppConfig {
+        AppConfig {
+            component: String::from("unknown"),
+            project: String::from("Actix Alerting Email"),
+            web_root: String::from("/"),
+            main_directory: String::new(),
+            config_file: String::new(),
+            mail_worker: 2,
+            smtp: SMTPConfig::new(),
+        }
+    }
+
+    pub fn from_yaml() -> AppConfig {
+        let config_yaml = "---
+component: 'unknown'
+project: 'Actix Alerting Email'
+web_root: '/'
+main_directory: ''
+config file: ''
+mail_worker: 2
+smtp:
+  host: ''
+  port: ''
+  login: ''
+  password: ''
+  full_name: ''
+  email_address: ''
+";
+        // Deserialize it back to a Rust type.
+        let config: AppConfig = match serde_yaml::from_str(&config_yaml) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                eprintln!("Default Config could not be parsed: {:?}", e);
+                AppConfig::new()
+            }
+        };
+
+        config
+    }
+
+    pub fn from_file() -> AppConfig {
+        let mut config: Option<AppConfig> = None;
+
+        match try_find_file(Path::new(&*CONFIG_FILE)) {
+            Ok(file) => {
+                config = match try_config_from_path(&file) {
+                    Ok(cfg) => Some(cfg),
+                    Err(e) => {
+                        eprintln!("Config File {:?}: File could not be read: {:?}", file, e);
+                        None
+                    }
+                };
+            }
+            Err(e) => {
+                eprintln!(
+                    "Config File '{}': File could not be found: {:?}",
+                    CONFIG_FILE, e
+                );
+            }
+        };
+
+        if config.is_none() {
+            eprintln!("Falling back to default configuration ...");
+            config = Some(AppConfig::from_yaml());
+        }
+
+        match config {
+            Some(cfg) => cfg,
+            None => AppConfig::new(),
+        }
+    }
+}
+
+impl Clone for AppConfig {
+    /*----------------------------------------------------------------------------
+     * Administrative Methods
+     */
+
+    fn clone(&self) -> AppConfig {
+        AppConfig {
+            component: self.component.clone(),
+            project: self.project.clone(),
+            web_root: self.web_root.clone(),
+            main_directory: self.main_directory.clone(),
+            config_file: self.config_file.clone(),
+            mail_worker: self.mail_worker,
+            smtp: self.smtp.clone(),
+        }
+    }
+}
+
+//==============================================================================
+// Auxiliary Functions
+
+fn try_find_file(file: &Path) -> Result<PathBuf, Error> {
+    let work_dir = std::env::current_dir().map_err(|e| {
+        Error::new(
+            ErrorKind::NotFound,
+            format!(
+                "Working Directory: find directory failed with Error: {:?}",
+                e
+            ),
+        )
+    })?;
+    println!("Working Directory: '{}'", work_dir.display());
+
+    let mut search_dir: Option<&Path> = Some(Path::new(work_dir.as_path()));
+    let mut find_file: Option<PathBuf> = None;
+
+    while search_dir.is_some() && find_file.is_none() {
+        if let Some(d) = search_dir {
+            println!("Search Directory: '{}'", d.display());
+
+            let mut search_file = PathBuf::from(d);
+
+            search_file.push(file);
+
+            if search_file.exists() {
+                find_file = Some(search_file);
+            } else {
+                // Continue searching in Parent Directory
+                search_dir = d.parent();
+            }
+        } //if let Some(d) = search_dir
+    } //while search_dir.is_some() && find_file.is_none()
+
+    if let Some(f) = find_file {
+        Ok(f)
+    } else {
+        //Config File does not exist
+        Err(Error::new(
+            ErrorKind::NotFound,
+            format!(
+                "Working Directory '{}' - Config File {:?}: file does not exist in any parent directory!",
+                work_dir.display(),
+                file.file_name()
+            ),
+        ))
+    } //if let Some(f) = find_file
+}
+
+fn try_config_from_path(file: &Path) -> Result<AppConfig, Error> {
+    let config_yaml = fs::read_to_string(file).map_err(|e| {
+        Error::new(
+            ErrorKind::NotFound,
+            format!(
+                "Config File {:?}: read file failed with Error: '{:?}'",
+                file, e
+            ),
+        )
+    })?;
+    let config: AppConfig = serde_yaml::from_str(&config_yaml).map_err(|e| {
+        Error::new(
+            ErrorKind::Other,
+            format!(
+                "Config File {:?}: parse file failed with Error: '{:?}'",
+                file.file_name(),
+                e
+            ),
+        )
+    })?;
+
+    Ok(config)
+}
+
+#[allow(dead_code)]
+fn find_path_parent(current: &Path, name: &str) -> Option<PathBuf> {
+    let mut odir = None;
+
+    let osearch = Some(OsStr::new(name));
+
+    for p in current.ancestors() {
+        if odir.is_none() && p.is_dir() && p.file_name() == osearch {
+            odir = Some(p);
+        }
+    }
+
+    if let Some(d) = odir {
+        odir = d.parent();
+    }
+
+    match odir {
+        Some(d) => Some(PathBuf::from(d)),
+        None => None,
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,8 +14,8 @@ extern crate serde;
 extern crate serde_yaml;
 
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
 use std::ffi::OsStr;
+use std::fmt;
 use std::fs;
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
@@ -33,7 +33,7 @@ pub struct SMTPConfig {
     pub login: String,
     pub password: String,
     pub full_name: String,
-    pub email_address: String
+    pub email_address: String,
 }
 
 //==============================================================================
@@ -76,7 +76,7 @@ impl SMTPConfig {
             login: String::new(),
             password: String::new(),
             full_name: String::new(),
-            email_address: String::new()
+            email_address: String::new(),
         }
     }
 }
@@ -93,7 +93,7 @@ impl Clone for SMTPConfig {
             login: self.login.clone(),
             password: self.password.clone(),
             full_name: self.full_name.clone(),
-            email_address: self.email_address.clone()
+            email_address: self.email_address.clone(),
         }
     }
 }
@@ -105,16 +105,15 @@ impl fmt::Debug for SMTPConfig {
 
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SMTPConfig")
-         .field("host", &self.host)
-         .field("port", &self.port)
-         .field("login", &self.login)
-         .field("password", &"******")
-         .field("full_name", &self.full_name)
-         .field("email_address", &self.email_address)
-         .finish()
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("login", &self.login)
+            .field("password", &"******")
+            .field("full_name", &self.full_name)
+            .field("email_address", &self.email_address)
+            .finish()
     }
 }
-
 
 //==============================================================================
 // Structure AppConfig Implementation

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ extern crate serde;
 extern crate serde_yaml;
 
 use serde_derive::{Deserialize, Serialize};
+use std::fmt;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::{Error, ErrorKind};
@@ -25,7 +26,7 @@ const CONFIG_FILE: &'static str = ".env";
 // Structure SMTPConfig Declaration
 
 /// Structure for the SMTP Configuration
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SMTPConfig {
     pub host: String,
     pub port: String,
@@ -82,7 +83,7 @@ impl SMTPConfig {
 
 impl Clone for SMTPConfig {
     /*----------------------------------------------------------------------------
-     * Administrative Methods
+     * Administration Methods
      */
 
     fn clone(&self) -> SMTPConfig {
@@ -96,6 +97,24 @@ impl Clone for SMTPConfig {
         }
     }
 }
+
+impl fmt::Debug for SMTPConfig {
+    /*----------------------------------------------------------------------------
+     * Consultation Methods
+     */
+
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SMTPConfig")
+         .field("host", &self.host)
+         .field("port", &self.port)
+         .field("login", &self.login)
+         .field("password", &"******")
+         .field("full_name", &self.full_name)
+         .field("email_address", &self.email_address)
+         .finish()
+    }
+}
+
 
 //==============================================================================
 // Structure AppConfig Implementation

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,6 +1,6 @@
 /*
 * @author Bodo (Hugo) Barwich
-* @version 2022-03-10
+* @version 2024-02-04
 * @package Grafana Alerting
 * @subpackage Email Sending Actor
 
@@ -13,6 +13,22 @@
 use actix::prelude::*;
 use actix::Addr;
 use serde::{Deserialize, Serialize};
+
+use lettre::smtp::client::net::ClientTlsParameters;
+use lettre::smtp::{
+    authentication::Credentials, authentication::Mechanism, extension::ClientId, SmtpClient,
+    SmtpTransport,
+};
+use lettre::{ClientSecurity, Transport};
+use lettre_email::{EmailBuilder, Header};
+use native_tls::TlsConnector;
+
+use core::time::Duration;
+
+use super::config::SMTPConfig;
+
+//==============================================================================
+// Structure EmailData Declaration
 
 /// Structure for Incoming Data
 #[derive(Debug, Serialize, Deserialize)]
@@ -38,32 +54,61 @@ pub struct EmailError {
     report: String,
 }
 
+//==============================================================================
+// Structure EmailData Implementation
+
 impl Message for EmailData {
     type Result = Result<EmailResponse, EmailError>;
 }
 
-/*
-impl<A, M> MessageResponse<A, M> for EmailResponse
-where
-    A: Actor,
-    M: Message<Result = EmailResponse>,
-{
-    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
-        if let Some(tx) = tx {
-            tx.send(self);
-        }
+//==============================================================================
+// Structure EmailSender Declaration
+
+/// Structure for the Email Sending
+// Define actor
+pub struct EmailSender {
+  config: SMTPConfig
+}
+
+
+//==============================================================================
+// Structure EmailSender Implementation
+
+impl Default for EmailSender {
+    /*----------------------------------------------------------------------------
+     * Default Constructor
+     */
+
+    fn default() -> Self {
+        Self::new()
     }
 }
-*/
 
-// Define actor
-pub struct EmailSender;
+impl EmailSender {
+    /*----------------------------------------------------------------------------
+     * Constructors
+     */
 
-/* -> EmailSender::Result
-impl Message for EmailSender {
-    type Result = Result<EmailResponse, EmailError>;
+    pub fn new() -> Self {
+        Self {
+            config: SMTPConfig::new(),
+        }
+    }
+
+    pub fn from_config(config: &SMTPConfig) -> Self {
+        Self {
+            config: config.clone(),
+        }
+    }
+
+    /*----------------------------------------------------------------------------
+     * Administration Methods
+     */
+
+    pub fn set_config(&mut self, config: &SMTPConfig) {
+        self.config = config.clone();
+    }
 }
-*/
 
 // Provide Actor implementation for EmailSender
 impl Actor for EmailSender {
@@ -71,6 +116,7 @@ impl Actor for EmailSender {
 
     fn started(&mut self, _ctx: &mut Self::Context) {
         println!("Email Sender Actor is alive");
+        println!("smtp config: {:?}", self.config);
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
@@ -80,18 +126,72 @@ impl Actor for EmailSender {
 
 /// Define handler for `EmailData` structure
 impl Handler<EmailData> for EmailSender {
-    //type Result = MessageResult<EmailData>;
-    //type Result = ResponseActFuture<Self, Result<EmailResponse, EmailError>>;
     type Result = Result<EmailResponse, EmailError>;
 
     fn handle(&mut self, mail: EmailData, _ctx: &mut Self::Context) -> Self::Result {
         println!("Email Data: '{:?}'", &mail);
 
-        //MessageResult(EmailResponse {status: String::from("sent"), report: String::from("")})
-        Ok(EmailResponse {
-            status: String::from("sent"),
-            report: String::from("Email was sent"),
-        })
+        let security = ClientSecurity::Required(ClientTlsParameters::new(
+            self.config.host.clone(),
+            TlsConnector::new().unwrap(),
+        ));
+        let smtp_url = self.config.host.clone() + ":" + self.config.port.as_str();
+
+        match SmtpClient::new(smtp_url, security) {
+            Ok(smtp) => {
+                let mut mailer = SmtpTransport::new(
+                    smtp.hello_name(ClientId::hostname())
+                        .credentials(Credentials::new(
+                            self.config.login.clone(),
+                            self.config.password.clone(),
+                        ))
+                        .authentication_mechanism(Mechanism::Login)
+                        .timeout(Some(Duration::new(15, 0))),
+                );
+
+                let message = mail.message.as_bytes().to_owned();
+
+                println!("send message: '{:?}'", &message);
+
+                let email = EmailBuilder::new()
+                    // Addresses can be specified by the tuple (email, alias)
+                    // ... or by an address only
+                    .from((self.config.email_address.as_str(), self.config.full_name.as_str()))
+                    .header(Header::new("X-Forward-From".to_owned(), mail.from.clone()))
+                    .to((self.config.email_address.as_str(), self.config.full_name.as_str()))
+                    .subject(mail.subject.as_str())
+                    .text(mail.message.as_str())
+                    .build()
+                    .unwrap();
+
+                // Send the email via remote relay
+                match mailer.send(email.into()) {
+                    Ok(res) => {
+                        mailer.close();
+
+                        Ok(EmailResponse {
+                            status: String::from("sent"),
+                            report: format!(
+                                "Email was sent with [{:?}]: {:?}",
+                                res.code, res.message
+                            ),
+                        })
+                    }
+                    Err(e) => {
+                        mailer.close();
+
+                        Err(EmailError {
+                            status: String::from("failed"),
+                            report: format!("Sending Error - SmtpTransport: '{:?}'", e),
+                        })
+                    }
+                }
+            }
+            Err(e) => Err(EmailError {
+                status: String::from("failed"),
+                report: format!("Sending Error - SmtpClient: '{:?}'", e),
+            }),
+        }
     }
 }
 

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -67,9 +67,8 @@ impl Message for EmailData {
 /// Structure for the Email Sending
 // Define actor
 pub struct EmailSender {
-  config: SMTPConfig
+    config: SMTPConfig,
 }
-
 
 //==============================================================================
 // Structure EmailSender Implementation
@@ -156,9 +155,15 @@ impl Handler<EmailData> for EmailSender {
                 let email = EmailBuilder::new()
                     // Addresses can be specified by the tuple (email, alias)
                     // ... or by an address only
-                    .from((self.config.email_address.as_str(), self.config.full_name.as_str()))
+                    .from((
+                        self.config.email_address.as_str(),
+                        self.config.full_name.as_str(),
+                    ))
                     .header(Header::new("X-Forward-From".to_owned(), mail.from.clone()))
-                    .to((self.config.email_address.as_str(), self.config.full_name.as_str()))
+                    .to((
+                        self.config.email_address.as_str(),
+                        self.config.full_name.as_str(),
+                    ))
                     .subject(mail.subject.as_str())
                     .text(mail.message.as_str())
                     .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 * @author Bodo (Hugo) Barwich
-* @version 2022-03-13
+* @version 2024-02-04
 * @package Grafana Alerting
 * @subpackage Email Micro Service
 
@@ -18,8 +18,11 @@
 //#[macro_use]
 extern crate json;
 
+pub mod config;
 pub mod email;
 pub mod ping;
+
+use std::env;
 
 use actix::sync::SyncArbiter;
 use actix_web::{error, web, App, Error, HttpResponse, HttpServer};
@@ -31,6 +34,7 @@ use serde::{Deserialize, Serialize};
 
 use actix_web::middleware::Logger;
 
+use config::AppConfig;
 use email::{EmailData, EmailLink, EmailSender};
 
 const MAX_SIZE: usize = 262_144; // max payload size is 256k
@@ -60,7 +64,7 @@ pub async fn dispatch_home_page() -> HttpResponse {
     //Project Description
 
     HttpResponse::Ok().json(ResponseData {
-        title: String::from("Grafana Alerting Email"),
+        title: String::from("Actix Alerting Email"),
         statuscode: 200,
         page: String::from("Home"),
         description: String::from("Email Sending Micro Service for the Grafana Alerting Project"),
@@ -162,35 +166,66 @@ pub async fn dispatch_ping_request() -> Result<HttpResponse, Error> {
     }
 }
 
+//==============================================================================
+// Executing Section
+
 #[actix_web::main]
 pub async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    println!("Email App: launching at 127.0.0.1:3100 ...");
+    let config = AppConfig::from_file();
+
+    println!("app config: {:?}", config);
+
+    let component_name = match env::var("COMPONENT") {
+        Ok(comp) => comp,
+        Err(_) => "default".to_owned(),
+    };
+
+    let mut app_host = String::from("127.0.0.1");
+    let app_port = match env::var("PORT") {
+        Ok(p) => p,
+        Err(_) => "3100".to_owned(),
+    };
+
+    app_host.push(':');
+    app_host.push_str(app_port.as_str());
+
+    println!(
+        "Email App '{}': launching at {} ...",
+        component_name, app_host
+    );
+
+    //Clone the SMTP Config for the Email Worker
+    let smtp_config = config.smtp.clone();
 
     //Create 2 Email Sender Instances
-    let sender = SyncArbiter::start(2, || EmailSender);
+    let sender = SyncArbiter::start(config.mail_worker as usize, move || {
+        EmailSender::from_config(&smtp_config)
+     });
     //Create 1 Email Link Object
     let link = EmailLink::new(sender);
 
     HttpServer::new(move || {
+        let app_config = web::Data::new(config.clone());
         let link_data = web::Data::new(link.clone());
 
         App::new()
             .app_data(link_data)
-            .app_data(web::JsonConfig::default().limit(4096)) // <- limit size of the payload (global configuration)
-            .service(web::resource("/").route(web::get().to(dispatch_home_page)))
-            .service(web::resource("/send").route(web::post().to(send_email)))
-            .service(web::resource("/mjsonrust").route(web::post().to(index_mjsonrust)))
-            .service(web::resource("/ping").route(web::get().to(dispatch_ping_request)))
+            .app_data(web::JsonConfig::default().limit(MAX_SIZE)) // <- limit size of the payload (global configuration)
+            .service(web::resource(app_config.web_root.as_str()).route(web::get().to(dispatch_home_page)))
+            .service(web::resource(app_config.web_root.as_str().to_owned() + "send").route(web::post().to(send_email)))
+            .service(web::resource(app_config.web_root.as_str().to_owned() + "mjsonrust").route(web::post().to(index_mjsonrust)))
+            .service(web::resource(app_config.web_root.as_str().to_owned() + "ping").route(web::get().to(dispatch_ping_request)))
+            .app_data(app_config)
             .wrap(Logger::default())
     })
-    .bind("127.0.0.1:3100")?
+    .bind(app_host)?
     .run()
     .await?;
 
-    println!("Email App: finished.");
+    println!("Email App '{}': finished.", component_name);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub async fn main() -> std::io::Result<()> {
     //Create 2 Email Sender Instances
     let sender = SyncArbiter::start(config.mail_worker as usize, move || {
         EmailSender::from_config(&smtp_config)
-     });
+    });
     //Create 1 Email Link Object
     let link = EmailLink::new(sender);
 
@@ -214,10 +214,22 @@ pub async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(link_data)
             .app_data(web::JsonConfig::default().limit(MAX_SIZE)) // <- limit size of the payload (global configuration)
-            .service(web::resource(app_config.web_root.as_str()).route(web::get().to(dispatch_home_page)))
-            .service(web::resource(app_config.web_root.as_str().to_owned() + "send").route(web::post().to(send_email)))
-            .service(web::resource(app_config.web_root.as_str().to_owned() + "mjsonrust").route(web::post().to(index_mjsonrust)))
-            .service(web::resource(app_config.web_root.as_str().to_owned() + "ping").route(web::get().to(dispatch_ping_request)))
+            .service(
+                web::resource(app_config.web_root.as_str())
+                    .route(web::get().to(dispatch_home_page)),
+            )
+            .service(
+                web::resource(app_config.web_root.as_str().to_owned() + "send")
+                    .route(web::post().to(send_email)),
+            )
+            .service(
+                web::resource(app_config.web_root.as_str().to_owned() + "mjsonrust")
+                    .route(web::post().to(index_mjsonrust)),
+            )
+            .service(
+                web::resource(app_config.web_root.as_str().to_owned() + "ping")
+                    .route(web::get().to(dispatch_ping_request)),
+            )
             .app_data(app_config)
             .wrap(Logger::default())
     })

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -78,7 +78,7 @@ mod tests {
             to: String::from("receiver@testmail.com"),
             message: String::from("Mail Test - ")
                 + config.component.as_str()
-                + "\n===============\n\nmy test email message",
+                + "\n=============================\n\nmy test email message",
         };
         let req = test::TestRequest::post()
             .uri("/send")


### PR DESCRIPTION
The SMTP Settings will be read from the configuration file `.env`.
This file must be created for each deployment environment.
These settings must be protected correctly since they contain the login credentials for the Email Provider.

A Sample file is provided at `.env_sample` which shows possible settings and the structure layout.